### PR TITLE
small update to cope with larger call volume

### DIFF
--- a/nixstatsagent/plugins/asterisk.py
+++ b/nixstatsagent/plugins/asterisk.py
@@ -3,13 +3,13 @@
 import plugins
 import subprocess
 
-### You need to add `nixstats ALL=(ALL) NOPASSWD: /usr/sbin/asterisk` to /etc/sudoers in order for this to work
+
 class Plugin(plugins.BasePlugin):
     __name__ = 'asterisk'
 
     def run(self, *unused):
         p = subprocess.Popen("sudo asterisk -rx 'core show calls' | grep 'active' | cut -f1 -d ' '", stdout=subprocess.PIPE, shell=True)
-        p, err = p.communicate()[0].decode('utf-8')
+        p = p.communicate()[0].decode('utf-8').replace("\n", "")
         p = { "calls": p }
         return p
 


### PR DESCRIPTION
This is really to avoid the plugin returning a `Execution error: too many values to unpack` when call volume is high.