### PR TITLE
Support for counting active sessions in Janus WebRTC Gateway

### DIFF
--- a/nixstatsagent/plugins/janus.py
+++ b/nixstatsagent/plugins/janus.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*- 
+import plugins
+import subprocess
+
+
+class Plugin(plugins.BasePlugin):
+    __name__ = 'janus'
+
+    def run(self, config):
+        adminpw = config.get('janus', 'adminpw')
+        p = subprocess.Popen("curl -s -H \"Accept: application/json\" -H \"Content-type: application/json\" -X POST -d '{ \"janus\": \"list_sessions\", \"transaction\": \"324\", \"admin_secret\": \"$
+        p = p.communicate()[0].decode('utf-8').replace("\n", "")
+        res = { "janus_sessions": p }
+        return res
+
+if __name__ == '__main__':
+    Plugin().execute()

--- a/nixstatsagent/plugins/janus.py
+++ b/nixstatsagent/plugins/janus.py
@@ -9,7 +9,7 @@ class Plugin(plugins.BasePlugin):
 
     def run(self, config):
         adminpw = config.get('janus', 'adminpw')
-        p = subprocess.Popen("curl -s -H \"Accept: application/json\" -H \"Content-type: application/json\" -X POST -d '{ \"janus\": \"list_sessions\", \"transaction\": \"324\", \"admin_secret\": \"$
+        p = subprocess.Popen("curl -s -H \"Accept: application/json\" -H \"Content-type: application/json\" -X POST -d '{ \"janus\": \"list_sessions\", \"transaction\": \"324\", \"admin_secret\": \""+adminpw+"\" }' http://localhost:7088/admin | awk 'NR>=5' | head -n -2 | wc -l", stdout=subprocess.PIPE, shell=True)
         p = p.communicate()[0].decode('utf-8').replace("\n", "")
         res = { "janus_sessions": p }
         return res


### PR DESCRIPTION
Depends on this config in nixstats.ini
```
[janus]
enabled=yes
adminpw=YourAdminPass
```
Output of plugin:
```
{
    "janus_sessions": "83"
}
``` 
https://janus.conf.meetecho.com/